### PR TITLE
Add pilot and copilot spawning to helicopter control component

### DIFF
--- a/EnfusionExtendedFramework/Scripts/Game/EEF_HelicopterControlComponent.c
+++ b/EnfusionExtendedFramework/Scripts/Game/EEF_HelicopterControlComponent.c
@@ -197,7 +197,7 @@ class EEF_HelicopterControlComponent : ScriptComponent
             m_PilotEntity = SpawnCrewMember(owner, m_sPilotPrefab, ECompartmentType.PILOT, "pilot");
 
         if (!m_sCopilotPrefab.IsEmpty())
-            m_CopilotEntity = SpawnCrewMember(owner, m_sCopilotPrefab, ECompartmentType.TURRET, "copilot");
+            m_CopilotEntity = SpawnCrewMember(owner, m_sCopilotPrefab, ECompartmentType.PILOT, "copilot");
     }
 
     protected IEntity SpawnCrewMember(IEntity owner, ResourceName prefab, ECompartmentType compartmentType, string role)

--- a/EnfusionExtendedFramework/Scripts/Game/EEF_HelicopterControlComponent.c
+++ b/EnfusionExtendedFramework/Scripts/Game/EEF_HelicopterControlComponent.c
@@ -160,7 +160,7 @@ class EEF_HelicopterControlComponent : ScriptComponent
 
         SetEventMask(owner, EntityEvent.FRAME);
 
-        SpawnCrew(owner);
+        GetGame().GetCallqueue().CallLater(SpawnCrew, 1000, false);
 
         DebugLog("Initialised.");
     }
@@ -182,6 +182,60 @@ class EEF_HelicopterControlComponent : ScriptComponent
         }
 
         super.OnDelete(owner);
+    }
+
+    protected void SpawnCrew()
+    {
+        if (!Replication.IsServer())
+            return;
+
+        IEntity owner = GetOwner();
+        if (!owner)
+            return;
+
+        if (!m_sPilotPrefab.IsEmpty())
+            m_PilotEntity = SpawnCrewMember(owner, m_sPilotPrefab, ECompartmentType.PILOT, "pilot");
+
+        if (!m_sCopilotPrefab.IsEmpty())
+            m_CopilotEntity = SpawnCrewMember(owner, m_sCopilotPrefab, ECompartmentType.TURRET, "copilot");
+    }
+
+    protected IEntity SpawnCrewMember(IEntity owner, ResourceName prefab, ECompartmentType compartmentType, string role)
+    {
+        Resource res = Resource.Load(prefab);
+        if (!res || !res.IsValid())
+        {
+            Print(string.Format("[EEF HelicopterControl] WARNING: Could not load %1 prefab: %2", role, prefab), LogLevel.WARNING);
+            return null;
+        }
+
+        EntitySpawnParams spawnParams = new EntitySpawnParams();
+        spawnParams.TransformMode = ETransformMode.WORLD;
+        Math3D.MatrixIdentity4(spawnParams.Transform);
+        spawnParams.Transform[3] = owner.GetOrigin();
+
+        IEntity crew = GetGame().SpawnEntityPrefab(res, GetGame().GetWorld(), spawnParams);
+        if (!crew)
+        {
+            Print(string.Format("[EEF HelicopterControl] WARNING: Failed to spawn %1 entity.", role), LogLevel.WARNING);
+            return null;
+        }
+
+        SCR_CompartmentAccessComponent access = SCR_CompartmentAccessComponent.Cast(
+            crew.FindComponent(SCR_CompartmentAccessComponent)
+        );
+        if (!access)
+        {
+            Print(string.Format("[EEF HelicopterControl] WARNING: %1 entity missing SCR_CompartmentAccessComponent.", role), LogLevel.WARNING);
+            return crew;
+        }
+
+        if (!access.MoveInVehicle(owner, compartmentType))
+            Print(string.Format("[EEF HelicopterControl] WARNING: No %1 compartment slot found on vehicle prefab.", role), LogLevel.WARNING);
+        else
+            DebugLog(string.Format("%1 spawned and seated.", role));
+
+        return crew;
     }
 
     protected void AutoStartFlight(IEntity owner)

--- a/EnfusionExtendedFramework/Scripts/Game/EEF_HelicopterControlComponent.c
+++ b/EnfusionExtendedFramework/Scripts/Game/EEF_HelicopterControlComponent.c
@@ -86,6 +86,12 @@ class EEF_HelicopterControlComponent : ScriptComponent
     [Attribute("0", UIWidgets.CheckBox, "Print debug flight information to the server log.")]
     protected bool m_bDebugLog;
 
+    [Attribute("", UIWidgets.ResourceNamePicker, "Prefab path for the pilot character. Leave empty to spawn no pilot.", "et")]
+    protected ResourceName m_sPilotPrefab;
+
+    [Attribute("", UIWidgets.ResourceNamePicker, "Prefab path for the copilot character. Leave empty to spawn no copilot.", "et")]
+    protected ResourceName m_sCopilotPrefab;
+
     // --------------------------------------------------------
     // RUNTIME STATE
     // --------------------------------------------------------
@@ -106,6 +112,8 @@ class EEF_HelicopterControlComponent : ScriptComponent
     protected int m_iSplineProgressIndex;
     //! Throttle for status debug logs (per-second).
     protected float m_fStatusLogTimer;
+    protected IEntity m_PilotEntity;
+    protected IEntity m_CopilotEntity;
 
     // --------------------------------------------------------
     // CONSTANTS
@@ -151,7 +159,29 @@ class EEF_HelicopterControlComponent : ScriptComponent
         }
 
         SetEventMask(owner, EntityEvent.FRAME);
+
+        SpawnCrew(owner);
+
         DebugLog("Initialised.");
+    }
+
+    override void OnDelete(IEntity owner)
+    {
+        if (Replication.IsServer())
+        {
+            if (m_PilotEntity)
+            {
+                SCR_EntityHelper.DeleteEntityAndChildren(m_PilotEntity);
+                m_PilotEntity = null;
+            }
+            if (m_CopilotEntity)
+            {
+                SCR_EntityHelper.DeleteEntityAndChildren(m_CopilotEntity);
+                m_CopilotEntity = null;
+            }
+        }
+
+        super.OnDelete(owner);
     }
 
     protected void AutoStartFlight(IEntity owner)


### PR DESCRIPTION
## Summary
Added functionality to automatically spawn pilot and copilot characters into helicopters controlled by the EEF_HelicopterControlComponent. The crew members are spawned via configurable prefab paths and automatically seated in the appropriate compartments.

## Key Changes
- Added two new attributes (`m_sPilotPrefab` and `m_sCopilotPrefab`) to allow configuration of crew member prefabs via the editor
- Implemented `SpawnCrew()` method that spawns pilot and copilot entities 1 second after helicopter initialization
- Implemented `SpawnCrewMember()` helper method that handles:
  - Loading and validating prefab resources
  - Spawning entities at the helicopter's location
  - Moving spawned crew into the appropriate vehicle compartments
  - Comprehensive error logging for debugging
- Added `OnDelete()` override to properly clean up spawned crew entities when the helicopter is deleted
- Added runtime state variables to track spawned pilot and copilot entities

## Implementation Details
- Crew spawning is delayed by 1 second to ensure the helicopter is fully initialized before attempting to seat crew
- Spawning only occurs on the server to maintain proper network synchronization
- Both pilot and copilot prefabs are optional (can be left empty to spawn no crew)
- Detailed warning messages are logged if prefab loading, entity spawning, or compartment access fails
- Crew entities are properly cleaned up on helicopter deletion to prevent orphaned entities

https://claude.ai/code/session_016Xh7bYScJPmZsbMcxme2Ri